### PR TITLE
Change addChunk to operate on Buffer not on string

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -15,12 +15,19 @@ class VEDirectParser extends EventEmitter {
     this.line = []
     this.data = {}
     this.cache = ''
+    this.sum = 0
   }
 
-  addChunk (chunk) {
-    if (typeof chunk !== 'string') {
-      return
+  addChunk (buf) {
+    if (!Buffer.isBuffer(buf)) {
+      return this.warn('addChunk: incoming data is not a buffer: ' + typeof buf)
     }
+
+    const chunk = buf.toString('ascii')
+
+    buf.forEach(b => {
+      this.sum += b
+    })
 
     this.cache += chunk
     if (chunk.toLowerCase().includes('checksum')) {
@@ -65,15 +72,10 @@ class VEDirectParser extends EventEmitter {
   }
 
   _verifyCacheAndParse () {
-    let sum = 0
-    let i = this.cache.length
-    while (i--) {
-      sum += this.cache.charCodeAt(i)
-    }
-
-    if (sum % 265 !== 0) {
+    if (this.sum % 256 !== 0) {
+      this.warn(`block checksum doesn't equal 0: ${this.sum % 256}`)
       this.cache = ''
-      this.warn(`block checksum doesn't equal 0: ${sum % 256}`)
+      this.sum = 0
       return
     }
 
@@ -83,7 +85,7 @@ class VEDirectParser extends EventEmitter {
       .map(line => line.trim())
       .filter(line => line !== '')
       .forEach(line => {
-        this.line = line.split('\n')
+        this.line = line.split('\t')
         this._parse()
       })
 

--- a/lib/serial.js
+++ b/lib/serial.js
@@ -13,10 +13,7 @@ exports.open = function openSerialConnection (device, parser) {
   port = new SerialPort(device, { baudRate: 19200 }) // @NOTE FT: should this be configurable?
 
   port.on('data', chunk => {
-    if (Buffer.isBuffer(chunk)) {
-      chunk = chunk.toString('ascii')
-    }
-
+    // Chunk is a node.js Buffer
     parser.addChunk(chunk)
   })
 


### PR DESCRIPTION
Changelog: 

- `lib/serial.js` - don't cast incoming data to string
- sum bytes in incoming Buffer as opposed to summing `charCodeAt(n)`'s
- Small bugfix in `_verifyCacheAndParse`